### PR TITLE
K convention

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Run installation.
       run: |
         python -m pip install torch==2.3.0 torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        python -m pip install torch-sparse -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
         python -m pip install torch-geometric
         python -m pip install sphinx sphinx_rtd_theme
         python -m pip install -e .[test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
     - name: Run installation.
       run: |
         python -m pip install torch==2.3.0 torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
-        python -m pip install torch-scatter -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
-        python -m pip install torch-sparse -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
         python -m pip install torch-geometric
         python -m pip install sphinx sphinx_rtd_theme
         python -m pip install -e .[test]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 install_requires = [
     "torch",
-    "torch_sparse",
     "scikit-learn",
     "torch_geometric",
     "numpy",

--- a/test/directed_test.py
+++ b/test/directed_test.py
@@ -58,7 +58,7 @@ def test_MagNet():
         num_nodes, num_classes
     )
 
-    model = MagNet_node_classification(X.shape[1], K=3, label_dim=num_classes, layer=3, trainable_q=True,
+    model = MagNet_node_classification(X.shape[1], K=2, label_dim=num_classes, layer=3, trainable_q=True,
                                        activation=True, hidden=2, dropout=0.5, cached=True).to(device)
     preds = model(X, X, edge_index, edge_weight)
 
@@ -71,7 +71,7 @@ def test_MagNet():
         num_nodes, num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MagNetConv(3, 2, K=3, normalization=sym)'
+    ) == 'MagNetConv(3, 2, filter size=3, normalization=sym)'
 
     model.reset_parameters()
 
@@ -98,7 +98,7 @@ def test_MagNet_Link():
         len(link_data[0]['train']['edges']), num_classes
     )
 
-    model = MagNet_link_prediction(data.x.shape[1], K=3, label_dim=num_classes, layer=3, trainable_q=True,
+    model = MagNet_link_prediction(data.x.shape[1], K=2, label_dim=num_classes, layer=3, trainable_q=True,
                                    activation=True, hidden=2, dropout=0.5).to(device)
     preds = model(data.x, data.x, link_data[0]['graph'], query_edges=link_data[0]['train']['edges'],
                   edge_weight=link_data[0]['weights'])
@@ -107,7 +107,7 @@ def test_MagNet_Link():
         len(link_data[0]['train']['edges']), num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MagNetConv(3, 2, K=3, normalization=sym)'
+    ) == 'MagNetConv(3, 2, filter size=3, normalization=sym)'
 
     num_classes = 3
     link_data = link_class_split(

--- a/test/directed_test.py
+++ b/test/directed_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import torch
-from torch_sparse import SparseTensor
+from torch_geometric.typing import SparseTensor
 
 from torch_geometric_signed_directed.nn import (
     DiGCN_node_classification, DiGCN_Inception_Block_node_classification,

--- a/test/signed_test.py
+++ b/test/signed_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import torch
-from torch_sparse import SparseTensor
+from torch_geometric.typing import SparseTensor
 from torch_geometric_signed_directed.nn import (
     SSSNET_node_clustering, SDGNN, SGCN, SiGAT, SNEA, SGCNConv, SNEAConv
 )

--- a/torch_geometric_signed_directed/data/directed/WikipediaNetwork.py
+++ b/torch_geometric_signed_directed/data/directed/WikipediaNetwork.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable
 import os.path as osp
-from torch_sparse import coalesce
+from torch_geometric.utils import coalesce
 
 import torch
 import numpy as np

--- a/torch_geometric_signed_directed/data/directed/WikipediaNetwork.py
+++ b/torch_geometric_signed_directed/data/directed/WikipediaNetwork.py
@@ -69,7 +69,7 @@ class WikipediaNetwork(InMemoryDataset):
             data = f.read().split('\n')[1:-1]
             data = [[int(v) for v in r.split('\t')] for r in data]
             edge_index = torch.tensor(data, dtype=torch.long).t().contiguous()
-            edge_index, _ = coalesce(edge_index, None, x.size(0), x.size(0))
+            edge_index, _ = coalesce(edge_index, None, x.size(0))
 
         train_masks, val_masks, test_masks = [], [], []
         for f in self.raw_paths[2:]:

--- a/torch_geometric_signed_directed/nn/directed/DGCNConv.py
+++ b/torch_geometric_signed_directed/nn/directed/DGCNConv.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 from torch_geometric.typing import Adj, OptTensor
 
 from torch import Tensor
-from torch_sparse import SparseTensor, matmul
+from torch_geometric.typing import SparseTensor, torch_sparse
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
 
@@ -99,4 +99,4 @@ class DGCNConv(MessagePassing):
         return x_j if edge_weight is None else edge_weight.view(-1, 1) * x_j
 
     def message_and_aggregate(self, adj_t: SparseTensor, x: Tensor) -> Tensor:
-        return matmul(adj_t, x, reduce=self.aggr)
+        return torch_sparse.mul(adj_t, x, reduce=self.aggr)

--- a/torch_geometric_signed_directed/nn/directed/MagNetConv.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNetConv.py
@@ -19,7 +19,7 @@ class MagNetConv(MessagePassing):
     Args:
         in_channels (int): Size of each input sample.
         out_channels (int): Size of each output sample.
-        K (int): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.
+        K (int): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1:math:`K`.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         trainable_q (bool, optional): whether to set q to be trainable or not. (default: :obj:`False`)
         normalization (str, optional): The normalization scheme for the magnetic
@@ -59,7 +59,7 @@ class MagNetConv(MessagePassing):
             self.q = Parameter(torch.Tensor(1).fill_(q))
         else:
             self.q = q
-        self.weight = Parameter(torch.Tensor(K, in_channels, out_channels))
+        self.weight = Parameter(torch.Tensor(K+1, in_channels, out_channels))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -252,6 +252,6 @@ class MagNetConv(MessagePassing):
         return norm.view(-1, 1) * x_j
 
     def __repr__(self):
-        return '{}({}, {}, K={}, normalization={})'.format(
+        return '{}({}, {}, filter size={}, normalization={})'.format(
             self.__class__.__name__, self.in_channels, self.out_channels,
             self.weight.size(0), self.normalization)

--- a/torch_geometric_signed_directed/nn/directed/MagNet_link_prediction.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNet_link_prediction.py
@@ -15,7 +15,7 @@ class MagNet_link_prediction(nn.Module):
     Args:
         num_features (int): Size of each input sample.
         hidden (int, optional): Number of hidden channels.  Default: 2.
-        K (int, optional): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.  Default: 2.
+        K (int, optional): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.  Default: 1.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         label_dim (int, optional): Number of output classes.  Default: 2.
         activation (bool, optional): whether to use activation function or not. (default: :obj:`True`)
@@ -36,7 +36,7 @@ class MagNet_link_prediction(nn.Module):
             learning scenarios. (default: :obj:`False`)
     """
 
-    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 2, label_dim: int = 2,
+    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 1, label_dim: int = 2,
                  activation: bool = True, trainable_q: bool = False, layer: int = 2, dropout: float = 0.5, normalization: str = 'sym', cached: bool = False):
         super(MagNet_link_prediction, self).__init__()
 

--- a/torch_geometric_signed_directed/nn/directed/MagNet_node_classification.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNet_node_classification.py
@@ -15,7 +15,7 @@ class MagNet_node_classification(nn.Module):
     Args:
         num_features (int): Size of each input sample.
         hidden (int, optional): Number of hidden channels.  Default: 2.
-        K (int, optional): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.  Default: 2.
+        K (int, optional): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.  Default: 1.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         label_dim (int, optional): Number of output classes.  Default: 2.
         activation (bool, optional): whether to use activation function or not. (default: :obj:`False`)

--- a/torch_geometric_signed_directed/nn/general/MSConv.py
+++ b/torch_geometric_signed_directed/nn/general/MSConv.py
@@ -16,7 +16,7 @@ class MSConv(MessagePassing):
     Args:
         in_channels (int): Size of each input sample.
         out_channels (int): Size of each output sample.
-        K (int): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.
+        K (int): Order of the Chebyshev polynomial, i.e., Chebyshev filter size mimus 1:math:`K`.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         trainable_q (bool, optional): whether to set q to be trainable or not. (default: :obj:`False`)
         normalization (str, optional): The normalization scheme for the magnetic
@@ -59,7 +59,7 @@ class MSConv(MessagePassing):
             self.q = Parameter(torch.Tensor(1).fill_(q))
         else:
             self.q = q
-        self.weight = Parameter(torch.Tensor(K, in_channels, out_channels))
+        self.weight = Parameter(torch.Tensor(K+1, in_channels, out_channels))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -234,6 +234,6 @@ class MSConv(MessagePassing):
         return norm.view(-1, 1) * x_j
 
     def __repr__(self):
-        return '{}({}, {}, K={}, normalization={})'.format(
+        return '{}({}, {}, filter size={}, normalization={})'.format(
             self.__class__.__name__, self.in_channels, self.out_channels,
             self.weight.size(0), self.normalization)

--- a/torch_geometric_signed_directed/nn/general/MSGNN.py
+++ b/torch_geometric_signed_directed/nn/general/MSGNN.py
@@ -14,7 +14,7 @@ class MSGNN_link_prediction(nn.Module):
     Args:
         num_features (int): Size of each input sample.
         hidden (int, optional): Number of hidden channels.  Default: 2.
-        K (int, optional): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.  Default: 2.
+        K (int, optional): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1:math:`K`.  Default: 1.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         label_dim (int, optional): Number of output classes.  Default: 2.
         activation (bool, optional): whether to use activation function or not. (default: :obj:`True`)
@@ -36,7 +36,7 @@ class MSGNN_link_prediction(nn.Module):
         conv_bias (bool, optional): Whether to use bias in the convolutional layers, default :obj:`True`.
         absolute_degree (bool, optional): Whether to calculate the degree matrix with respect to absolute entries of the adjacency matrix. (default: :obj:`True`)
     """
-    def __init__(self, num_features:int, hidden:int=2, q:float=0.25, K:int=2, label_dim:int=2, \
+    def __init__(self, num_features:int, hidden:int=2, q:float=0.25, K:int=1, label_dim:int=2, \
         activation:bool=True, trainable_q:bool=False, layer:int=2, dropout:float=0.5, normalization:str='sym', 
         cached: bool=False, conv_bias: bool=True, absolute_degree: bool=True):
         super(MSGNN_link_prediction, self).__init__()

--- a/torch_geometric_signed_directed/nn/general/conv_base.py
+++ b/torch_geometric_signed_directed/nn/general/conv_base.py
@@ -3,10 +3,9 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 from torch_geometric.typing import Adj, OptTensor
-from torch_scatter import scatter_add
-from torch_sparse import SparseTensor
+from torch_geometric.typing import SparseTensor
 from torch_geometric.nn.conv import MessagePassing
-from torch_geometric.utils import add_remaining_self_loops
+from torch_geometric.utils import add_remaining_self_loops, scatter
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 
 
@@ -26,7 +25,7 @@ def conv_norm_rw(edge_index, fill_value=0.5, edge_weight=None, num_nodes=None,
         edge_weight = tmp_edge_weight
 
     row = edge_index[0]
-    row_deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    row_deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv = row_deg.pow_(-1)
     deg_inv.masked_fill_(deg_inv == float('inf'), 0)
     return edge_index, deg_inv[row] * edge_weight

--- a/torch_geometric_signed_directed/nn/signed/SGCNConv.py
+++ b/torch_geometric_signed_directed/nn/signed/SGCNConv.py
@@ -5,7 +5,7 @@ import torch
 from torch import Tensor
 import torch.nn.functional as F
 from torch_geometric.nn.dense.linear import Linear
-from torch_sparse import SparseTensor, matmul
+from torch_geometric.typing import SparseTensor, torch_sparse
 from torch_geometric.nn.conv import MessagePassing
 
 
@@ -130,7 +130,7 @@ class SGCNConv(MessagePassing):
     def message_and_aggregate(self, adj_t: SparseTensor,
                               x: PairTensor) -> Tensor:
         adj_t = adj_t.set_value(None, layout=None)
-        return matmul(adj_t, x[0], reduce=self.aggr)
+        return torch_sparse.mul(adj_t, x[0], reduce=self.aggr)
 
     def __repr__(self) -> str:
         return (f'{self.__class__.__name__}({self.in_dim}, '

--- a/torch_geometric_signed_directed/utils/directed/get_adjs_DiGCN.py
+++ b/torch_geometric_signed_directed/utils/directed/get_adjs_DiGCN.py
@@ -1,8 +1,7 @@
 from typing import Union, Optional, Tuple
 
 import torch
-from torch_geometric.utils import add_self_loops
-from torch_scatter import scatter_add
+from torch_geometric.utils import add_self_loops, scatter
 import scipy
 import numpy as np
 import scipy.sparse as sp
@@ -104,7 +103,7 @@ def cal_fast_appr(alpha: float, edge_index: torch.LongTensor,
 
     # sys normalization
     row, col = edge_index
-    deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv_sqrt = deg.pow(-0.5)
     deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
 
@@ -137,7 +136,7 @@ def get_appr_directed_adj(alpha: float, edge_index: torch.LongTensor,
     edge_index, edge_weight = add_self_loops(
         edge_index, edge_weight, fill_value, num_nodes)
     row, col = edge_index
-    deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv = deg.pow(-1)
     deg_inv[deg_inv == float('inf')] = 0
     p = deg_inv[row] * edge_weight
@@ -189,7 +188,7 @@ def get_appr_directed_adj(alpha: float, edge_index: torch.LongTensor,
 
     # row normalization
     row, col = edge_index
-    deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv_sqrt = deg.pow(-0.5)
     deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
 
@@ -221,7 +220,7 @@ def get_second_directed_adj(edge_index: torch.LongTensor,
     edge_index, edge_weight = add_self_loops(
         edge_index, edge_weight, fill_value, num_nodes)
     row, col = edge_index
-    deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv = deg.pow(-1)
     deg_inv[deg_inv == float('inf')] = 0
     p = deg_inv[row] * edge_weight
@@ -248,7 +247,7 @@ def get_second_directed_adj(edge_index: torch.LongTensor,
 
     # row normalization
     row, col = edge_index
-    deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight, row, dim=0, dim_size=num_nodes, reduce='sum')
     deg_inv_sqrt = deg.pow(-0.5)
     deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
 

--- a/torch_geometric_signed_directed/utils/directed/get_magnetic_Laplacian.py
+++ b/torch_geometric_signed_directed/utils/directed/get_magnetic_Laplacian.py
@@ -1,9 +1,7 @@
 from typing import Optional
 
 import torch
-from torch_scatter import scatter_add
-from torch_sparse import coalesce
-from torch_geometric.utils import add_self_loops, remove_self_loops, to_scipy_sparse_matrix
+from torch_geometric.utils import add_self_loops, remove_self_loops, to_scipy_sparse_matrix, coalesce, scatter
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 import numpy as np
 from scipy.sparse.linalg import eigsh
@@ -66,7 +64,7 @@ def get_magnetic_Laplacian(edge_index: torch.LongTensor, edge_weight: Optional[t
     edge_weight_sym = edge_weight_sym/2
 
     row, col = edge_index_sym[0], edge_index_sym[1]
-    deg = scatter_add(edge_weight_sym, row, dim=0, dim_size=num_nodes)
+    deg = scatter(edge_weight_sym, row, dim=0, dim_size=num_nodes, reduce='sum')
 
     edge_weight_q = torch.exp(1j * 2 * np.pi * q * edge_attr[:, 1])
 

--- a/torch_geometric_signed_directed/utils/directed/get_magnetic_Laplacian.py
+++ b/torch_geometric_signed_directed/utils/directed/get_magnetic_Laplacian.py
@@ -57,8 +57,7 @@ def get_magnetic_Laplacian(edge_index: torch.LongTensor, edge_weight: Optional[t
     sym_attr = torch.cat([edge_weight, edge_weight], dim=0)
     edge_attr = torch.stack([sym_attr, theta_attr], dim=1)
 
-    edge_index_sym, edge_attr = coalesce(edge_index, edge_attr, num_nodes,
-                                         num_nodes, "add")
+    edge_index_sym, edge_attr = coalesce(edge_index, edge_attr, num_nodes, "add")
 
     edge_weight_sym = edge_attr[:, 0]
     edge_weight_sym = edge_weight_sym/2

--- a/torch_geometric_signed_directed/utils/general/get_magnetic_signed_Laplacian.py
+++ b/torch_geometric_signed_directed/utils/general/get_magnetic_signed_Laplacian.py
@@ -1,9 +1,7 @@
 from typing import Optional
 
 import torch
-from torch_scatter import scatter_add
-from torch_sparse import coalesce
-from torch_geometric.utils import add_self_loops, remove_self_loops, to_scipy_sparse_matrix
+from torch_geometric.utils import add_self_loops, remove_self_loops, to_scipy_sparse_matrix, coalesce, scatter
 from torch_geometric.utils.num_nodes import maybe_num_nodes
 import numpy as np
 from scipy.sparse.linalg import eigsh
@@ -71,9 +69,9 @@ def get_magnetic_signed_Laplacian(edge_index: torch.LongTensor, edge_weight: Opt
     if absolute_degree:
         edge_weight_abs_sym = edge_attr[:, 2]
         edge_weight_abs_sym = edge_weight_abs_sym/2
-        deg = scatter_add(edge_weight_abs_sym, row, dim=0, dim_size=num_nodes)
+        deg = scatter(edge_weight_abs_sym, row, dim=0, dim_size=num_nodes, reduce='sum')
     else:
-        deg = scatter_add(torch.abs(edge_weight_sym), row, dim=0, dim_size=num_nodes) # absolute values for edge weights
+        deg = scatter(torch.abs(edge_weight_sym), row, dim=0, dim_size=num_nodes, reduce='sum') # absolute values for edge weights
 
     edge_weight_q = torch.exp(1j * 2* np.pi * q * edge_attr[:, 1])
 

--- a/torch_geometric_signed_directed/utils/general/get_magnetic_signed_Laplacian.py
+++ b/torch_geometric_signed_directed/utils/general/get_magnetic_signed_Laplacian.py
@@ -59,8 +59,7 @@ def get_magnetic_signed_Laplacian(edge_index: torch.LongTensor, edge_weight: Opt
     sym_abs_attr = torch.cat([torch.abs(edge_weight), torch.abs(edge_weight)], dim=0)
     edge_attr = torch.stack([sym_attr, theta_attr, sym_abs_attr], dim=1)
 
-    edge_index_sym, edge_attr = coalesce(edge_index, edge_attr, num_nodes,
-                                     num_nodes, "add")
+    edge_index_sym, edge_attr = coalesce(edge_index, edge_attr, num_nodes, "add")
 
     row, col = edge_index_sym[0], edge_index_sym[1]
     edge_weight_sym = edge_attr[:, 0]

--- a/torch_geometric_signed_directed/utils/signed/create_spectral_features.py
+++ b/torch_geometric_signed_directed/utils/signed/create_spectral_features.py
@@ -27,7 +27,7 @@ def create_spectral_features(
     edge_index = torch.cat([edge_index, torch.stack([col, row])], dim=1)
     val = torch.cat([val, val], dim=0)
 
-    edge_index, val = coalesce(edge_index, val, N, N)
+    edge_index, val = coalesce(edge_index, val, N)
     val = val - 1
 
     # Borrowed from:

--- a/torch_geometric_signed_directed/utils/signed/create_spectral_features.py
+++ b/torch_geometric_signed_directed/utils/signed/create_spectral_features.py
@@ -2,7 +2,7 @@
 import torch
 import scipy.sparse as sp
 from sklearn.decomposition import TruncatedSVD
-from torch_sparse import coalesce
+from torch_geometric.utils import coalesce
 
 
 def create_spectral_features(


### PR DESCRIPTION
Many people have contacted me regarding the K convention in MagNet and MSGNN, and hence I am changing both to match the paper 'K' parameter so that 'K' will denote the order of the Chebyshev polynomial instead of the filter size.