### PR TITLE
K_convention to represent cheb polynomial order

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test coverage.
       run: |
-        python setup.py test
+        pytest
     - name: Run codecov
       if: success()
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest]
         torch-version: [2.3.0]
         include:

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ pip install torch-geometric-signed-directed
 **Running tests**
 
 ```
-$ python setup.py test
+$ pytest
 ```
 --------------------------------------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
 [metadata]
-description-file = README.md
-
-[aliases]
-test=pytest
+description_file = README.md
 
 [tool:pytest]
 addopts = --capture=no --cov

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ setup(
     download_url='{}/archive/{}.tar.gz'.format(url, __version__),
     keywords=keywords,
     install_requires=install_requires,
-    setup_requires=setup_requires,
-    tests_require=tests_require,
+    extras_require=extras_require,
     python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ install_requires = [
     "scipy"
 ]
 
-setup_requires = ["pytest-runner"]
-
-tests_require = ["pytest", "pytest-cov", "mock"]
+extras_require = {
+    "test": ["pytest", "pytest-cov", "mock"]
+}
 
 keywords = [
     "machine-learning",

--- a/test/directed_test.py
+++ b/test/directed_test.py
@@ -58,7 +58,7 @@ def test_MagNet():
         num_nodes, num_classes
     )
 
-    model = MagNet_node_classification(X.shape[1], K=3, label_dim=num_classes, layer=3, trainable_q=True,
+    model = MagNet_node_classification(X.shape[1], K=2, label_dim=num_classes, layer=3, trainable_q=True,
                                        activation=True, hidden=2, dropout=0.5, cached=True).to(device)
     preds = model(X, X, edge_index, edge_weight)
 
@@ -71,7 +71,7 @@ def test_MagNet():
         num_nodes, num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MagNetConv(3, 2, K=3, normalization=sym)'
+    ) == 'MagNetConv(3, 2, filter size=3, normalization=sym)'
 
     model.reset_parameters()
 
@@ -98,7 +98,7 @@ def test_MagNet_Link():
         len(link_data[0]['train']['edges']), num_classes
     )
 
-    model = MagNet_link_prediction(data.x.shape[1], K=3, label_dim=num_classes, layer=3, trainable_q=True,
+    model = MagNet_link_prediction(data.x.shape[1], K=2, label_dim=num_classes, layer=3, trainable_q=True,
                                    activation=True, hidden=2, dropout=0.5).to(device)
     preds = model(data.x, data.x, link_data[0]['graph'], query_edges=link_data[0]['train']['edges'],
                   edge_weight=link_data[0]['weights'])
@@ -107,7 +107,7 @@ def test_MagNet_Link():
         len(link_data[0]['train']['edges']), num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MagNetConv(3, 2, K=3, normalization=sym)'
+    ) == 'MagNetConv(3, 2, filter size=3, normalization=sym)'
 
     num_classes = 3
     link_data = link_class_split(

--- a/test/general_test.py
+++ b/test/general_test.py
@@ -135,7 +135,7 @@ def test_MSGNN():
         num_nodes, num_classes
     )
 
-    model = MSGNN_node_classification(q=0.25, K=3, num_features=X.shape[1], hidden=2, label_dim=num_classes, 
+    model = MSGNN_node_classification(q=0.25, K=2, num_features=X.shape[1], hidden=2, label_dim=num_classes, 
         dropout=0.5, cached=True, normalization=None).to(device)
     _, _, _, preds = model(X, X, edge_index=edge_index, 
                     edge_weight=edge_weight)
@@ -150,7 +150,7 @@ def test_MSGNN():
         num_nodes, num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MSConv(3, 2, K=3, normalization=None)'
+    ) == 'MSConv(3, 2, filter size=3, normalization=None)'
 
     model.reset_parameters()
 
@@ -167,7 +167,7 @@ def test_MSGNN_Link():
     data = SignedData(x=X, edge_index=edge_index, edge_weight=edge_weight)
     link_data = link_class_split(data, splits=2, task="four_class_signed_digraph", prob_val=0.15, prob_test=0.1, seed=10, device=device)
 
-    model = MSGNN_link_prediction(q=0.25, K=3, num_features=num_features, hidden=2, label_dim=num_classes, \
+    model = MSGNN_link_prediction(q=0.25, K=2, num_features=num_features, hidden=2, label_dim=num_classes, \
             trainable_q = False, dropout=0.5, cached=True).to(device)
     preds = model(data.x, data.x, edge_index=link_data[0]['graph'], query_edges=link_data[0]['train']['edges'],
                   edge_weight=link_data[0]['weights'])
@@ -183,7 +183,7 @@ def test_MSGNN_Link():
         len(link_data[0]['train']['edges']), num_classes
     )
     assert model.Chebs[0].__repr__(
-    ) == 'MSConv(3, 2, K=3, normalization=sym)'
+    ) == 'MSConv(3, 2, filter size=3, normalization=sym)'
 
     num_classes = 5
     link_data = link_class_split(data, splits=2, task="five_class_signed_digraph", prob_val=0.15, prob_test=0.1, seed=10, device=device)

--- a/torch_geometric_signed_directed/nn/directed/MagNetConv.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNetConv.py
@@ -19,7 +19,7 @@ class MagNetConv(MessagePassing):
     Args:
         in_channels (int): Size of each input sample.
         out_channels (int): Size of each output sample.
-        K (int): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.
+        K (int): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         trainable_q (bool, optional): whether to set q to be trainable or not. (default: :obj:`False`)
         normalization (str, optional): The normalization scheme for the magnetic
@@ -59,7 +59,7 @@ class MagNetConv(MessagePassing):
             self.q = Parameter(torch.Tensor(1).fill_(q))
         else:
             self.q = q
-        self.weight = Parameter(torch.Tensor(K, in_channels, out_channels))
+        self.weight = Parameter(torch.Tensor(K+1, in_channels, out_channels))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -252,6 +252,6 @@ class MagNetConv(MessagePassing):
         return norm.view(-1, 1) * x_j
 
     def __repr__(self):
-        return '{}({}, {}, K={}, normalization={})'.format(
+        return '{}({}, {}, filter size={}, normalization={})'.format(
             self.__class__.__name__, self.in_channels, self.out_channels,
             self.weight.size(0), self.normalization)

--- a/torch_geometric_signed_directed/nn/directed/MagNet_link_prediction.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNet_link_prediction.py
@@ -15,7 +15,7 @@ class MagNet_link_prediction(nn.Module):
     Args:
         num_features (int): Size of each input sample.
         hidden (int, optional): Number of hidden channels.  Default: 2.
-        K (int, optional): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.  Default: 2.
+        K (int, optional): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.  Default: 1.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         label_dim (int, optional): Number of output classes.  Default: 2.
         activation (bool, optional): whether to use activation function or not. (default: :obj:`True`)
@@ -36,7 +36,7 @@ class MagNet_link_prediction(nn.Module):
             learning scenarios. (default: :obj:`False`)
     """
 
-    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 2, label_dim: int = 2,
+    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 1, label_dim: int = 2,
                  activation: bool = True, trainable_q: bool = False, layer: int = 2, dropout: float = 0.5, normalization: str = 'sym', cached: bool = False):
         super(MagNet_link_prediction, self).__init__()
 

--- a/torch_geometric_signed_directed/nn/directed/MagNet_node_classification.py
+++ b/torch_geometric_signed_directed/nn/directed/MagNet_node_classification.py
@@ -15,7 +15,7 @@ class MagNet_node_classification(nn.Module):
     Args:
         num_features (int): Size of each input sample.
         hidden (int, optional): Number of hidden channels.  Default: 2.
-        K (int, optional): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.  Default: 2.
+        K (int, optional): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.  Default: 1.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         label_dim (int, optional): Number of output classes.  Default: 2.
         activation (bool, optional): whether to use activation function or not. (default: :obj:`False`)
@@ -37,7 +37,7 @@ class MagNet_node_classification(nn.Module):
             learning scenarios. (default: :obj:`False`)
     """
 
-    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 2, label_dim: int = 2,
+    def __init__(self, num_features: int, hidden: int = 2, q: float = 0.25, K: int = 1, label_dim: int = 2,
                  activation: bool = False, trainable_q: bool = False, layer: int = 2, dropout: float = False, normalization: str = 'sym', cached: bool = False):
         super(MagNet_node_classification, self).__init__()
 

--- a/torch_geometric_signed_directed/nn/general/MSConv.py
+++ b/torch_geometric_signed_directed/nn/general/MSConv.py
@@ -16,7 +16,7 @@ class MSConv(MessagePassing):
     Args:
         in_channels (int): Size of each input sample.
         out_channels (int): Size of each output sample.
-        K (int): Order of the Chebyshev polynomial plus 1, i.e., Chebyshev filter size :math:`K`.
+        K (int): Order of the Chebyshev polynomial, i.e., Chebyshev filter size minus 1 :math:`K`.
         q (float, optional): Initial value of the phase parameter, 0 <= q <= 0.25. Default: 0.25.
         trainable_q (bool, optional): whether to set q to be trainable or not. (default: :obj:`False`)
         normalization (str, optional): The normalization scheme for the magnetic
@@ -59,7 +59,7 @@ class MSConv(MessagePassing):
             self.q = Parameter(torch.Tensor(1).fill_(q))
         else:
             self.q = q
-        self.weight = Parameter(torch.Tensor(K, in_channels, out_channels))
+        self.weight = Parameter(torch.Tensor(K+1, in_channels, out_channels))
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -234,6 +234,6 @@ class MSConv(MessagePassing):
         return norm.view(-1, 1) * x_j
 
     def __repr__(self):
-        return '{}({}, {}, K={}, normalization={})'.format(
+        return '{}({}, {}, filter size={}, normalization={})'.format(
             self.__class__.__name__, self.in_channels, self.out_channels,
             self.weight.size(0), self.normalization)


### PR DESCRIPTION
Due to popular request to match the code convention to the K parameter in papers, I have updated K parameter in MagNet and MSGNN codes to represent the Cheb polynomial order instead of filter size, which is filter size minus 1.